### PR TITLE
config.jsonLocale support

### DIFF
--- a/pyreportjasper/config.py
+++ b/pyreportjasper/config.py
@@ -28,6 +28,7 @@ class Config:
     xmlXpath = None
     jsonQuery = None
     jsonQLQuery = None
+    jsonLocale = None
     locale = 'pt_BR'
     output = None
     outputFormats = None

--- a/pyreportjasper/report.py
+++ b/pyreportjasper/report.py
@@ -182,6 +182,8 @@ class Report:
                     self.config.jsonQuery = self.get_main_dataset_query()
                 db = Db()
                 ds = db.get_json_datasource(self.config)
+                if self.config.jsonLocale:
+                    ds.setLocale(self.LocaleUtils.toLocale(self.config.jsonLocale))
                 self.jasper_print = self.jvJasperFillManager.fillReport(self.jasper_report, parameters, ds)
             elif self.config.dbType == 'jsonql':
                 if self.config.jsonQLQuery is None:


### PR DESCRIPTION
Let's assign a different locale to the json data different from the default locale.

example:

config.locale = "es_ES"
config.jsonLocale = "en_US"