### PR TITLE
Add Custom HTML Configuration for Exporting Reports

### DIFF
--- a/pyreportjasper/pyreportjasper.py
+++ b/pyreportjasper/pyreportjasper.py
@@ -125,7 +125,7 @@ class PyReportJasper:
         report.fill()
         return report        
 
-    def process_report(self):
+    def process_report(self, html_configurations=None):
         error = None
         base_input = os.path.splitext(self.config.input)
         if base_input[-1] == ".jrxml":
@@ -139,7 +139,7 @@ class PyReportJasper:
                 try:
                     formats_functions = {
                         'pdf': report.export_pdf,
-                        'html': report.export_html,
+                        'html': lambda: report.export_html(html_configurations),
                         'rtf': report.export_rtf,
                         'docx': report.export_docx,
                         'odt': report.export_odt,

--- a/pyreportjasper/report.py
+++ b/pyreportjasper/report.py
@@ -80,6 +80,7 @@ class Report:
         self.SimpleXlsxReportConfiguration = jpype.JPackage('net').sf.jasperreports.export.SimpleXlsxReportConfiguration
         self.JRCsvExporter = jpype.JPackage('net').sf.jasperreports.engine.export.JRCsvExporter
         self.SimpleCsvExporterConfiguration = jpype.JPackage('net').sf.jasperreports.export.SimpleCsvExporterConfiguration
+        self.SimpleHtmlExporterConfiguration = jpype.JPackage('net').sf.jasperreports.export.SimpleHtmlExporterConfiguration
         self.JRCsvMetadataExporter = jpype.JPackage('net').sf.jasperreports.engine.export.JRCsvMetadataExporter
         self.SimpleCsvMetadataExporterConfiguration = jpype.JPackage('net').sf.jasperreports.export.SimpleCsvMetadataExporterConfiguration
         self.JRSaver = jpype.JPackage('net').sf.jasperreports.engine.util.JRSaver
@@ -277,11 +278,14 @@ class Report:
         output_stream_pdf.flush() # if no buffer used, it can be ignored.
         output_stream_pdf.close()       
 
-    def export_html(self):
+    def export_html(self,html_configurations=None):
         exporter = self.HtmlExporter()
         exporter.setExporterInput(self.SimpleExporterInput(self.jasper_print))
         output_stream = self.SimpleHtmlExporterOutput(self.get_output_stream(".html"))
         exporter.setExporterOutput(output_stream)
+        configuration = self.SimpleHtmlExporterConfiguration()
+        configuration.setHtmlHeader(html_configurations)
+        exporter.setConfiguration(configuration)
         exporter.exportReport()
 
     def export_rtf(self):


### PR DESCRIPTION
Description:
This pull request introduces a new feature to customize HTML configurations for exporting reports in the HTML format. Users can now specify their own HTML header and footer content to be included in the exported HTML file.Like the report content should be on entire HTML page,give styles to particular HTML tag etc.

Changes Made:

Added support for custom HTML header and footer content in the HTML exporter.
Updated the export_html function to accept custom HTML configurations.
Modified the generate_jasper_report function to allow users to pass custom HTML configurations.