### PR TITLE
added Config.jvm_opts to add arguments to the java call

### DIFF
--- a/pyreportjasper/config.py
+++ b/pyreportjasper/config.py
@@ -45,6 +45,7 @@ class Config:
     useJaxen = True
     subreports = {}
 
+    jvm_opts = ()
     jvm_maxmem = '512M'
     jvm_classpath = None
 

--- a/pyreportjasper/pyreportjasper.py
+++ b/pyreportjasper/pyreportjasper.py
@@ -45,7 +45,7 @@ class PyReportJasper:
     TypeJava = Report.TypeJava
 
     def config(self, input_file, output_file=False, output_formats=['pdf'], parameters={}, db_connection={},
-               locale='en_US', resource=None, subreports=None):
+               locale='en_US', resource=None, subreports=None, jvm_opts=()):
         if not input_file:
             raise NameError('No input file!')
         if isinstance(output_formats, list):
@@ -94,6 +94,8 @@ class PyReportJasper:
                     setattr(self.config, mapping[key], value)
                 elif key == 'csv_first_row':
                     self.config.csvFirstRow = True
+
+            self.config.jvm_opts = jvm_opts
 
     def compile(self, write_jasper=False):
         error = None

--- a/pyreportjasper/report.py
+++ b/pyreportjasper/report.py
@@ -62,13 +62,17 @@ class Report:
                 classpath.append(self.config.jvm_classpath)
 
             if self.config.jvm_classpath is None:
-                jpype.startJVM("-Djava.system.class.loader=org.update4j.DynamicClassLoader",
-                               "-Dlog4j.configurationFile={}".format(os.path.join(self.LIB_PATH, 'log4j2.xml')),
-                               "-XX:InitialHeapSize=512M",
-                               "-XX:CompressedClassSpaceSize=64M",
-                               "-XX:MaxMetaspaceSize=128M",                            
-                               "-Xmx{}".format(self.config.jvm_maxmem),
-                               classpath=classpath)
+                jvm_args = [
+                    "-Djava.system.class.loader=org.update4j.DynamicClassLoader",
+                    "-Dlog4j.configurationFile={}".format(
+                        os.path.join(self.LIB_PATH, 'log4j2.xml')),
+                    "-XX:InitialHeapSize=512M",
+                    "-XX:CompressedClassSpaceSize=64M",
+                    "-XX:MaxMetaspaceSize=128M",                            
+                    "-Xmx{}".format(self.config.jvm_maxmem),
+                ]
+                jvm_args.extend(self.config.jvm_opts or ())
+                jpype.startJVM(*jvm_args, classpath=classpath)
 
         self.Locale = jpype.JPackage('java').util.Locale
         self.String = jpype.JPackage('java').lang.String


### PR DESCRIPTION
I needed to pass the `-Djava.jwt.headless=true` argument to the java call, to avoid getting an error from java/jasper.

There was no way to do it, so I added:

-  a `jvm_opts` attribute to the `Config` class,
- that is set by the `PyReportJasper.config` method,
- and is read by the `Report.__init__` method.

Both `Config.jvm_opts` and `PyReportJasper.config(..., jvm_opts)` must be a tuple or list, containing zero or more strings; each string must be a valid argument accepted by the `java` executable.

Example of usage:
```
prj = PyReportJasper()
prj.config(..., jvm_opts=("-Djava.awt.headless=true",))
prj.process_report()
```
